### PR TITLE
Fix 6 vulnerable dependencies identified by Prisma Cloud

### DIFF
--- a/sca-package/pom.xml
+++ b/sca-package/pom.xml
@@ -8,7 +8,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.3.2</version>
+			<version>5.0.3</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
@@ -29,12 +29,12 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.4.0</version>
+			<version>2.15.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.4.0</version>
+			<version>2.16.0</version>
 		</dependency>
 	</dependencies>
   <build>

--- a/sca-package/requirements.txt
+++ b/sca-package/requirements.txt
@@ -1,3 +1,3 @@
-django==1.2
-flask==0.6
-requests==2.26.0
+django == 3.2.4 
+flask == 2.3.2 
+requests == 2.31.0 


### PR DESCRIPTION
Prisma Cloud has detected new vulnerabilities or dependencies in the scan performed on Wed, 03 Jan 2024 17:18:07 UTC

**This PR includes the fixes for the vulnerabilities discovered below:**
Severity | Dependency File | Package name | CVE | Risk Score | Fix Status | Description
-- | -- | -- | -- | -- | -- | --
critical | sca-package/requirements.txt | django | [CVE-2019-19844](https://nvd.nist.gov/vuln/detail/CVE-2019-19844) | 9.8 | fixed in 3.0.1, 2.2.9, 1.11.27 | 
critical | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2017-17485](https://nvd.nist.gov/vuln/detail/CVE-2017-17485) | 9.8 | fixed in 2.9.4, 2.8.11, 2.7.9.2,... | 
critical | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2017-7525](https://nvd.nist.gov/vuln/detail/CVE-2017-7525) | 9.8 | fixed in 2.8.9, 2.7.9.1, 2.6.7.1 | 
critical | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-7489](https://nvd.nist.gov/vuln/detail/CVE-2018-7489) | 9.8 | fixed in 2.9.5, 2.8.11.1, 2.7.9.3 | 
critical | sca-package/build.gradle | org.apache.logging.log4j_log4j-core | [CVE-2021-44228](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-44228) | 10.0 | fixed in 2.15.0, 2.12.2 | 
critical | sca-package/build.gradle | org.apache.logging.log4j_log4j-core | [CVE-2021-45046](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45046) | 9.0 | fixed in 2.16.0, 2.12.2, 2.3.1 | 
critical | sca-package/go.sum | github.com/emicklei/go-restful | [CVE-2022-1996](https://nvd.nist.gov/vuln/detail/CVE-2022-1996) | 9.1 | fixed in 2.16.0 | 
critical | sca-package/go.sum | github.com/hashicorp/go-getter | [CVE-2022-26945](https://nvd.nist.gov/vuln/detail/CVE-2022-26945) | 9.8 | fixed in 2.1.0, 1.6.1 | 
critical | sca-package/go.sum | github.com/Masterminds/goutils | [CVE-2021-4238](https://nvd.nist.gov/vuln/detail/CVE-2021-4238) | 9.1 | fixed in 1.1.1 | 
high | sca-package/requirements.txt | django | [CVE-2016-7401](https://nvd.nist.gov/vuln/detail/CVE-2016-7401) | 7.5 | fixed in 1.9.10, 1.8.15 | 
high | sca-package/requirements.txt | flask | [CVE-2023-30861](https://nvd.nist.gov/vuln/detail/CVE-2023-30861) | 7.5 | fixed in 2.3.2, 2.2.5 | 
high | sca-package/requirements.txt | flask | [CVE-2018-1000656](https://nvd.nist.gov/vuln/detail/CVE-2018-1000656) | 7.5 | fixed in 0.12.3 | 
high | sca-package/requirements.txt | flask | [CVE-2019-1010083](https://nvd.nist.gov/vuln/detail/CVE-2019-1010083) | 7.5 | fixed in 1.0 | 
high | sca-package/package-lock.json | fresh | [CVE-2017-16119](https://nvd.nist.gov/vuln/detail/CVE-2017-16119) | 7.5 | fixed in 0.5.2 | 
high | sca-package/package-lock.json | qs | [CVE-2022-24999](https://nvd.nist.gov/vuln/detail/CVE-2022-24999) | 7.5 | fixed in 6.10.3 | 
high | sca-package/package-lock.json | qs | [CVE-2017-1000048](https://nvd.nist.gov/vuln/detail/CVE-2017-1000048) | 7.5 | fixed in 6.3.2, 6.2.3, 6.1.2, 6.0.4 | 
high | sca-package/package-lock.json | mime | [CVE-2017-16138](https://nvd.nist.gov/vuln/detail/CVE-2017-16138) | 7.5 | fixed in 2.0.3, 1.4.1 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-core | [PRISMA-2023-0067](https://github.com/FasterXML/jackson-core/pull/827) | 7.5 | fixed in 2.15.0 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2022-42004](https://nvd.nist.gov/vuln/detail/CVE-2022-42004) | 7.5 | fixed in 2.13.4 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-10650](https://nvd.nist.gov/vuln/detail/CVE-2020-10650) | 8.1 | fixed in 2.9.10.5 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-35490](https://nvd.nist.gov/vuln/detail/CVE-2020-35490) | 8.1 | fixed in 2.9.10.8 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-35491](https://nvd.nist.gov/vuln/detail/CVE-2020-35491) | 8.1 | fixed in 2.9.10.8 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36518](https://nvd.nist.gov/vuln/detail/CVE-2020-36518) | 7.5 | fixed in 2.12.6.1, 2.13.2.1 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2021-20190](https://nvd.nist.gov/vuln/detail/CVE-2021-20190) | 8.1 | fixed in 2.9.10.7 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-24750](https://nvd.nist.gov/vuln/detail/CVE-2020-24750) | 8.1 | fixed in 2.9.10.6, 2.6.7.5 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-24616](https://nvd.nist.gov/vuln/detail/CVE-2020-24616) | 8.1 | fixed in 2.9.10.6 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36180](https://nvd.nist.gov/vuln/detail/CVE-2020-36180) | 8.1 | fixed in 2.6.7.5, 2.9.10.8 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36189](https://nvd.nist.gov/vuln/detail/CVE-2020-36189) | 8.1 | fixed in 2.6.7.5, 2.9.10.8 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36188](https://nvd.nist.gov/vuln/detail/CVE-2020-36188) | 8.1 | fixed in 2.6.7.5, 2.9.10.8 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36187](https://nvd.nist.gov/vuln/detail/CVE-2020-36187) | 8.1 | fixed in 2.9.10.8 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36186](https://nvd.nist.gov/vuln/detail/CVE-2020-36186) | 8.1 | fixed in 2.9.10.8 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36185](https://nvd.nist.gov/vuln/detail/CVE-2020-36185) | 8.1 | fixed in 2.9.10.8 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36184](https://nvd.nist.gov/vuln/detail/CVE-2020-36184) | 8.1 | fixed in 2.9.10.8 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36183](https://nvd.nist.gov/vuln/detail/CVE-2020-36183) | 8.1 | fixed in 2.6.7.5, 2.9.10.8 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36182](https://nvd.nist.gov/vuln/detail/CVE-2020-36182) | 8.1 | fixed in 2.6.7.5, 2.9.10.8 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36181](https://nvd.nist.gov/vuln/detail/CVE-2020-36181) | 8.1 | fixed in 2.6.7.5, 2.9.10.8 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36179](https://nvd.nist.gov/vuln/detail/CVE-2020-36179) | 8.1 | fixed in 2.6.7.5, 2.9.10.8 | 
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003) | 7.5 | fixed in 2.13.4.1, 2.12.7.1 | 
high | sca-package/build.gradle | org.apache.logging.log4j_log4j-core | [CVE-2021-45105](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45105) | 7.5 | fixed in 2.17.0, 2.12.3, 2.3.1 | 
high | sca-package/build.gradle | com.google.guava_guava | [CVE-2023-2976](https://nvd.nist.gov/vuln/detail/CVE-2023-2976) | 7.1 | fixed in 32.0.0 | 
high | sca-package/go.sum | gopkg.in/yaml.v3 | [CVE-2022-28948](https://nvd.nist.gov/vuln/detail/CVE-2022-28948) | 7.5 | fixed in 3.0.0-20220521103104-8f96da9f5d5e | 
high | sca-package/go.sum | github.com/go-git/go-git/v5 | [CVE-2023-49568](https://nvd.nist.gov/vuln/detail/CVE-2023-49568) | 7.5 | fixed in 5.11.0 | 
high | sca-package/go.sum | golang.org/x/crypto | [CVE-2021-43565](https://nvd.nist.gov/vuln/detail/CVE-2021-43565) | 7.5 | fixed in 0.0.0-20211202192323-5770296d904e | 
high | sca-package/go.sum | golang.org/x/crypto | [CVE-2022-27191](https://nvd.nist.gov/vuln/detail/CVE-2022-27191) | 7.5 | fixed in 0.0.0-20220314234659-1baeb1ce4c0b | 
high | sca-package/go.sum | github.com/hashicorp/go-getter | [CVE-2022-30323](https://nvd.nist.gov/vuln/detail/CVE-2022-30323) | 8.6 | fixed in 2.1.0, 1.6.1 | 
high | sca-package/go.sum | github.com/hashicorp/go-getter | [CVE-2022-30322](https://nvd.nist.gov/vuln/detail/CVE-2022-30322) | 8.6 | fixed in 2.1.0, 1.6.1 | 
high | sca-package/go.sum | github.com/hashicorp/go-getter | [CVE-2022-30321](https://nvd.nist.gov/vuln/detail/CVE-2022-30321) | 8.6 | fixed in 2.1.0, 1.6.1 | 
high | sca-package/go.sum | github.com/elazarl/goproxy | [CVE-2023-37788](https://nvd.nist.gov/vuln/detail/CVE-2023-37788) | 7.5 | fixed in 0.0.0-20230731152917-f99041a5c027 | 
high | sca-package/go.sum | golang.org/x/text | [CVE-2021-38561](https://nvd.nist.gov/vuln/detail/CVE-2021-38561) | 7.5 | fixed in 0.3.7 | 
high | sca-package/go.sum | golang.org/x/text | [CVE-2022-32149](https://nvd.nist.gov/vuln/detail/CVE-2022-32149) | 7.5 | fixed in 0.3.8 | 
high | sca-package/go.sum | google.golang.org/grpc | [GHSA-m425-mq94-257g](https://github.com/advisories/GHSA-m425-mq94-257g) | 7.5 | fixed in 1.58.3, 1.57.1, 1.56.3 | 
high | sca-package/go.sum | golang.org/x/net | [CVE-2022-41723](https://nvd.nist.gov/vuln/detail/CVE-2022-41723) | 7.5 | fixed in 0.7.0 | 
high | sca-package/go.sum | golang.org/x/net | [CVE-2022-27664](https://nvd.nist.gov/vuln/detail/CVE-2022-27664) | 7.5 | fixed in 0.0.0-20220906165146-f3363e06e74c | 
high | sca-package/go.sum | golang.org/x/net | [CVE-2023-39325](https://nvd.nist.gov/vuln/detail/CVE-2023-39325) | 7.5 | fixed in 0.17.0 | 
high | sca-package/go.sum | github.com/prometheus/client_golang | [CVE-2022-21698](https://nvd.nist.gov/vuln/detail/CVE-2022-21698) | 7.5 | fixed in 1.11.1 | 
medium | sca-package/requirements.txt | django | [CVE-2016-6186](https://nvd.nist.gov/vuln/detail/CVE-2016-6186) | 6.1 | fixed in 1.9.8, 1.8.14 | 
medium | sca-package/requirements.txt | django | [CVE-2021-33203](https://nvd.nist.gov/vuln/detail/CVE-2021-33203) | 4.9 | fixed in 3.2.4, 3.1.12, 2.2.24 | 
medium | sca-package/requirements.txt | django | [CVE-2015-8213](https://nvd.nist.gov/vuln/detail/CVE-2015-8213) | 5.0 | fixed in 1.8.7, 1.7.11, 1.7.x | 
medium | sca-package/requirements.txt | django | [CVE-2015-2317](https://nvd.nist.gov/vuln/detail/CVE-2015-2317) | 4.3 | fixed in 1.8.1, 1.7.7, 1.6.11,... | 
medium | sca-package/requirements.txt | django | [CVE-2015-2241](https://nvd.nist.gov/vuln/detail/CVE-2015-2241) | 4.3 | fixed in 1.8, 1.7.6 | 
medium | sca-package/requirements.txt | django | [CVE-2015-0222](https://nvd.nist.gov/vuln/detail/CVE-2015-0222) | 5.0 | fixed in 1.7.3, 1.6.10, 1.4.18 | 
medium | sca-package/requirements.txt | django | [CVE-2015-0221](https://nvd.nist.gov/vuln/detail/CVE-2015-0221) | 5.0 | fixed in 1.7.3, 1.6.10, 1.4.18 | 
medium | sca-package/requirements.txt | django | [CVE-2015-0220](https://nvd.nist.gov/vuln/detail/CVE-2015-0220) | 4.3 | fixed in 1.7.3, 1.6.10, 1.4.18 | 
medium | sca-package/requirements.txt | django | [CVE-2015-0219](https://nvd.nist.gov/vuln/detail/CVE-2015-0219) | 5.0 | fixed in 1.7.3, 1.6.10, 1.4.18 | 
medium | sca-package/requirements.txt | django | [CVE-2015-5144](https://nvd.nist.gov/vuln/detail/CVE-2015-5144) | 4.3 | fixed in 1.8.3, 1.7.10, 1.7.9,... | 
medium | sca-package/requirements.txt | requests | [CVE-2023-32681](https://nvd.nist.gov/vuln/detail/CVE-2023-32681) | 6.1 | fixed in 2.31.0 | 
medium | sca-package/package-lock.json | send | [CVE-2015-8859](https://nvd.nist.gov/vuln/detail/CVE-2015-8859) | 5.3 | fixed in 0.11.1 | 
medium | sca-package/package-lock.json | connect | [CVE-2018-3717](https://nvd.nist.gov/vuln/detail/CVE-2018-3717) | 5.4 | fixed in 2.14.0 | 
medium | sca-package/pom.xml | org.apache.httpcomponents_httpclient | [CVE-2020-13956](https://nvd.nist.gov/vuln/detail/CVE-2020-13956) | 5.3 | fixed in 5.0.3, 4.5.13 | 
medium | sca-package/pom.xml | org.apache.httpcomponents_httpclient | [CVE-2015-5262](https://nvd.nist.gov/vuln/detail/CVE-2015-5262) | 4.3 | fixed in 4.4.1, 4.3.6 | 
medium | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-core | [PRISMA-2023-0069](https://github.com/FasterXML/jackson-core/issues/315) | 5.3 | fixed in 2.7.7 | 
medium | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-core | [PRISMA-2023-0068](https://github.com/FasterXML/jackson-core/pull/322) | 5.3 | fixed in 2.8.6 | 
medium | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2023-35116](https://nvd.nist.gov/vuln/detail/CVE-2023-35116) | 4.7 | fixed in 2.16.0 | 
medium | sca-package/build.gradle | org.apache.logging.log4j_log4j-core | [CVE-2021-44832](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-44832) | 6.6 | fixed in 2.17.1, 2.12.4, 2.3.2 | 
medium | sca-package/go.sum | github.com/sirupsen/logrus | [PRISMA-2023-0056](https://github.com/sirupsen/logrus/issues/1370) | 6.2 | fixed in v1.9.3 | 
moderate | sca-package/go.sum | go.etcd.io/etcd | [CVE-2018-1099](https://nvd.nist.gov/vuln/detail/CVE-2018-1099) | 5.5 | fixed in 3.4.0 | 
moderate | sca-package/go.sum | golang.org/x/crypto | [CVE-2023-48795](https://nvd.nist.gov/vuln/detail/CVE-2023-48795) | 5.9 | fixed in 0.17.0 | 
moderate | sca-package/go.sum | golang.org/x/image | [CVE-2022-41727](https://nvd.nist.gov/vuln/detail/CVE-2022-41727) | 5.5 | fixed in 0.5.0 | 
moderate | sca-package/go.sum | golang.org/x/image | [CVE-2023-29408](https://nvd.nist.gov/vuln/detail/CVE-2023-29408) | 6.5 | fixed in 0.10.0 | 
moderate | sca-package/go.sum | golang.org/x/image | [CVE-2023-29407](https://nvd.nist.gov/vuln/detail/CVE-2023-29407) | 6.5 | fixed in 0.10.0 | 
moderate | sca-package/go.sum | github.com/hashicorp/go-getter | [CVE-2023-0475](https://nvd.nist.gov/vuln/detail/CVE-2023-0475) | 4.2 | fixed in 1.7.0 | 
moderate | sca-package/go.sum | github.com/hashicorp/go-getter | [CVE-2022-29810](https://nvd.nist.gov/vuln/detail/CVE-2022-29810) | 5.5 | fixed in 1.5.11 | 
moderate | sca-package/go.sum | golang.org/x/sys | [CVE-2022-29526](https://nvd.nist.gov/vuln/detail/CVE-2022-29526) | 5.3 | fixed in 0.0.0-20220412211240-33da011f77ad | 
moderate | sca-package/go.sum | google.golang.org/grpc | [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487) | 5.3 | fixed in 1.56.3, 1.57.1, 1.58.3 | 
moderate | sca-package/go.sum | golang.org/x/net | [CVE-2023-3978](https://nvd.nist.gov/vuln/detail/CVE-2023-3978) | 6.1 | fixed in 0.13.0 | 
moderate | sca-package/go.sum | golang.org/x/net | [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487) | 5.3 | fixed in 0.17.0 | 
low | sca-package/build.gradle | com.google.guava_guava | [CVE-2020-8908](https://nvd.nist.gov/vuln/detail/CVE-2020-8908) | 3.3 | fixed in 32.0.0 | 
low | sca-package/go.sum | github.com/Masterminds/goutils | [GHSA-xg2h-wx96-xgxr](https://github.com/advisories/GHSA-xg2h-wx96-xgxr) | 1.0 | fixed in 1.1.1 | 
