### PR TITLE
Fix 6 vulnerable dependencies identified by Prisma Cloud

### DIFF
--- a/sca-package/pom.xml
+++ b/sca-package/pom.xml
@@ -8,7 +8,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.3.2</version>
+			<version>5.0.3</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
@@ -29,12 +29,12 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.4.0</version>
+			<version>2.15.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.4.0</version>
+			<version>2.16.0</version>
 		</dependency>
 	</dependencies>
   <build>

--- a/sca-package/requirements.txt
+++ b/sca-package/requirements.txt
@@ -1,3 +1,3 @@
-django==1.2
-flask==0.6
-requests==2.26.0
+django == 3.2.4 
+flask == 2.3.2 
+requests == 2.31.0 


### PR DESCRIPTION
Prisma Cloud has detected new vulnerabilities or dependencies in the scan performed on Fri, 05 Jan 2024 17:17:33 UTC

**This PR includes the fixes for the vulnerabilities discovered below:**
Severity | Dependency File | Package name | CVE | Risk Score | Fix Status | Description
-- | -- | -- | -- | -- | -- | --
critical | sca-package/requirements.txt | django | [CVE-2019-19844](https://nvd.nist.gov/vuln/detail/CVE-2019-19844) | 9.8 | fixed in 3.0.1, 2.2.9, 1.11.27 | Django before 1.11.27, 2.x before 2.2.9, and 3.x before 3.0.1 allows account takeover. A suitably crafted email address (that is equal to an existing user\'s email address after case transformation of Unicode characters) would allow an attacker to be sent a password reset token for the matched user account. (One mitigation in the new releases is to send password reset tokens only to the registered user email address.)
critical | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2017-17485](https://nvd.nist.gov/vuln/detail/CVE-2017-17485) | 9.8 | fixed in 2.9.4, 2.8.11, 2.7.9.2,... | FasterXML jackson-databind through 2.8.10 and 2.9.x through 2.9.3 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist that is ineffective if the Spring libraries are available in the classpath.
critical | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2017-7525](https://nvd.nist.gov/vuln/detail/CVE-2017-7525) | 9.8 | fixed in 2.8.9, 2.7.9.1, 2.6.7.1 | A deserialization flaw was discovered in the jackson-databind, versions before 2.6.7.1, 2.7.9.1 and 2.8.9, which could allow an unauthenticated user to perform code execution by sending the maliciously crafted input to the readValue method of the ObjectMapper.
critical | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-7489](https://nvd.nist.gov/vuln/detail/CVE-2018-7489) | 9.8 | fixed in 2.9.5, 2.8.11.1, 2.7.9.3 | FasterXML jackson-databind before 2.7.9.3, 2.8.x before 2.8.11.1 and 2.9.x before 2.9.5 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist that is ineffective if the c3p0 libraries are available in the classpath.
critical | sca-package/build.gradle | org.apache.logging.log4j_log4j-core | [CVE-2021-44228](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-44228) | 10.0 | fixed in 2.15.0, 2.12.2 | Apache Log4j2 2.0-beta9 through 2.15.0 (excluding security releases 2.12.2, 2.12.3, and 2.3.1) JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled. From log4j 2.15.0, this behavior has been disabled by default. From version 2.16.0 (along with 2.12.2, 2.12.3, and 2.3.1), this functionality has been completely removed. Note that this vulnerability is specific to log4j-core and does not affect log4net, log4cxx, or other Apache Logging Services projects.
critical | sca-package/build.gradle | org.apache.logging.log4j_log4j-core | [CVE-2021-45046](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45046) | 9.0 | fixed in 2.16.0, 2.12.2, 2.3.1 | It was found that the fix to address CVE-2021-44228 in Apache Log4j 2.15.0 was incomplete in certain non-default configurations. This could allows attackers with control over Thread Context Map (MDC) input data when the logging configuration uses a non-default Pattern Layout with either a Context Lookup (for example, $${ctx:loginId}) or a Thread Context Map pattern (%X, %mdc, or %MDC) to craft malicious input data using a JNDI Lookup pattern resulting in an information leak and remote code execution in some environments and local code execution in all environments. Log4j 2.16.0 (Java 8) and 2.12.2 (Java 7) fix this issue by removing support for message lookup patterns and disabling JNDI functionality by default.
critical | sca-package/go.sum | github.com/emicklei/go-restful | [CVE-2022-1996](https://nvd.nist.gov/vuln/detail/CVE-2022-1996) | 9.1 | fixed in 2.16.0 | Authorization Bypass Through User-Controlled Key in GitHub repository emicklei/go-restful prior to v3.8.0.
critical | sca-package/go.sum | github.com/hashicorp/go-getter | [CVE-2022-26945](https://nvd.nist.gov/vuln/detail/CVE-2022-26945) | 9.8 | fixed in 2.1.0, 1.6.1 | go-getter up to 1.5.11 and 2.0.2 allowed protocol switching, endless redirect, and configuration bypass via abuse of custom HTTP response header processing. Fixed in 1.6.1 and 2.1.0.
critical | sca-package/go.sum | github.com/Masterminds/goutils | [CVE-2021-4238](https://nvd.nist.gov/vuln/detail/CVE-2021-4238) | 9.1 | fixed in 1.1.1 | Randomly-generated alphanumeric strings contain significantly less entropy than expected. The RandomAlphaNumeric and CryptoRandomAlphaNumeric functions always return strings containing at least one digit from 0 to 9. This significantly reduces the amount of entropy in short strings generated by these functions.
high | sca-package/requirements.txt | django | [CVE-2016-7401](https://nvd.nist.gov/vuln/detail/CVE-2016-7401) | 7.5 | fixed in 1.9.10, 1.8.15 | The cookie parsing code in Django before 1.8.15 and 1.9.x before 1.9.10, when used on a site with Google Analytics, allows remote attackers to bypass an intended CSRF protection mechanism by setting arbitrary cookies.
high | sca-package/requirements.txt | flask | [CVE-2023-30861](https://nvd.nist.gov/vuln/detail/CVE-2023-30861) | 7.5 | fixed in 2.3.2, 2.2.5 | Flask is a lightweight WSGI web application framework. When all of the following conditions are met, a response containing data intended for one client may be cached and subsequently sent by the proxy to other clients. If the proxy also caches `Set-Cookie` headers, it may send one client\'s `session` cookie to other clients. The severity depends on the application\'s use of the session and the proxy\'s behavior regarding cookies. The risk depends on all these conditions being met.  1. The application must be hosted behind a caching proxy that does not strip cookies or ignore responses with cookies. 2. The application sets `session.permanent = True` 3. The application does not access or modify the session at any point during a request. 4. `SESSION_REFRESH_EACH_REQUEST` enabled (the default). 5. The application does not set a `Cache-Control` header to indicate that a page is private or should not be cached.  This happens because vulnerable versions of Flask only set the `Vary: Cookie` header when the session is accessed or modified, not when it is refreshed (re-sent to update the expiration) without being accessed or modified. This issue has been fixed in versions 2.3.2 and 2.2.5.
high | sca-package/requirements.txt | flask | [CVE-2018-1000656](https://nvd.nist.gov/vuln/detail/CVE-2018-1000656) | 7.5 | fixed in 0.12.3 | The Pallets Project flask version Before 0.12.3 contains a CWE-20: Improper Input Validation vulnerability in flask that can result in Large amount of memory usage possibly leading to denial of service. This attack appear to be exploitable via Attacker provides JSON data in incorrect encoding. This vulnerability appears to have been fixed in 0.12.3. NOTE: this may overlap CVE-2019-1010083.
high | sca-package/requirements.txt | flask | [CVE-2019-1010083](https://nvd.nist.gov/vuln/detail/CVE-2019-1010083) | 7.5 | fixed in 1.0 | The Pallets Project Flask before 1.0 is affected by: unexpected memory usage. The impact is: denial of service. The attack vector is: crafted encoded JSON data. The fixed version is: 1. NOTE: this may overlap CVE-2018-1000656.
high | sca-package/package-lock.json | fresh | [CVE-2017-16119](https://nvd.nist.gov/vuln/detail/CVE-2017-16119) | 7.5 | fixed in 0.5.2 | Fresh is a module used by the Express.js framework for HTTP response freshness testing. It is vulnerable to a regular expression denial of service when it is passed specially crafted input to parse. This causes the event loop to be blocked causing a denial of service condition.
high | sca-package/package-lock.json | qs | [CVE-2022-24999](https://nvd.nist.gov/vuln/detail/CVE-2022-24999) | 7.5 | fixed in 6.10.3 | qs before 6.10.3, as used in Express before 4.17.3 and other products, allows attackers to cause a Node process hang for an Express application because an __ proto__ key can be used. In many typical Express use cases, an unauthenticated remote attacker can place the attack payload in the query string of the URL that is used to visit the application, such as a[__proto__]=b&a[__proto__]&a[length]=100000000. The fix was backported to qs 6.9.7, 6.8.3, 6.7.3, 6.6.1, 6.5.3, 6.4.1, 6.3.3, and 6.2.4 (and therefore Express 4.17.3, which has \"deps: qs@6.9.7\" in its release description, is not vulnerable).
high | sca-package/package-lock.json | qs | [CVE-2017-1000048](https://nvd.nist.gov/vuln/detail/CVE-2017-1000048) | 7.5 | fixed in 6.3.2, 6.2.3, 6.1.2, 6.0.4 | the web framework using ljharb\'s qs module older than v6.3.2, v6.2.3, v6.1.2, and v6.0.4 is vulnerable to a DoS. A malicious user can send a evil request to cause the web framework crash.
high | sca-package/package-lock.json | mime | [CVE-2017-16138](https://nvd.nist.gov/vuln/detail/CVE-2017-16138) | 7.5 | fixed in 2.0.3, 1.4.1 | The mime module < 1.4.1, 2.0.1, 2.0.2 is vulnerable to regular expression denial of service when a mime lookup is performed on untrusted user input.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-core | [PRISMA-2023-0067](https://github.com/FasterXML/jackson-core/pull/827) | 7.5 | fixed in 2.15.0 | com.fasterxml.jackson.core_jackson-core package versions before 2.15.0 are vulnerable to Denial of Service (DoS). The package does not properly restrict the size or amount of resources that are requested or influenced by an actor, which can be used to consume more resources than intended and leads to Uncontrolled Resource Consumption (\'Resource Exhaustion\').
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2022-42004](https://nvd.nist.gov/vuln/detail/CVE-2022-42004) | 7.5 | fixed in 2.13.4 | In FasterXML jackson-databind before 2.13.4, resource exhaustion can occur because of a lack of a check in BeanDeserializer._deserializeFromArray to prevent use of deeply nested arrays. An application is vulnerable only with certain customized choices for deserialization.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-10650](https://nvd.nist.gov/vuln/detail/CVE-2020-10650) | 8.1 | fixed in 2.9.10.5 | A deserialization flaw was discovered in jackson-databind through 2.9.10.4. It could allow an unauthenticated user to perform code execution via ignite-jta or quartz-core: org.apache.ignite.cache.jta.jndi.CacheJndiTmLookup, org.apache.ignite.cache.jta.jndi.CacheJndiTmFactory, and org.quartz.utils.JNDIConnectionProvider.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-35490](https://nvd.nist.gov/vuln/detail/CVE-2020-35490) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.dbcp2.datasources.PerUserPoolDataSource.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-35491](https://nvd.nist.gov/vuln/detail/CVE-2020-35491) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.dbcp2.datasources.SharedPoolDataSource.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36518](https://nvd.nist.gov/vuln/detail/CVE-2020-36518) | 7.5 | fixed in 2.12.6.1, 2.13.2.1 | jackson-databind before 2.13.0 allows a Java StackOverflow exception and denial of service via a large depth of nested objects.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2021-20190](https://nvd.nist.gov/vuln/detail/CVE-2021-20190) | 8.1 | fixed in 2.9.10.7 | A flaw was found in jackson-databind before 2.9.10.7. FasterXML mishandles the interaction between serialization gadgets and typing. The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-24750](https://nvd.nist.gov/vuln/detail/CVE-2020-24750) | 8.1 | fixed in 2.9.10.6, 2.6.7.5 | FasterXML jackson-databind 2.x before 2.9.10.6 mishandles the interaction between serialization gadgets and typing, related to com.pastdev.httpcomponents.configuration.JndiConfiguration.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-24616](https://nvd.nist.gov/vuln/detail/CVE-2020-24616) | 8.1 | fixed in 2.9.10.6 | FasterXML jackson-databind 2.x before 2.9.10.6 mishandles the interaction between serialization gadgets and typing, related to br.com.anteros.dbcp.AnterosDBCPDataSource (aka Anteros-DBCP).
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36180](https://nvd.nist.gov/vuln/detail/CVE-2020-36180) | 8.1 | fixed in 2.6.7.5, 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36189](https://nvd.nist.gov/vuln/detail/CVE-2020-36189) | 8.1 | fixed in 2.6.7.5, 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to com.newrelic.agent.deps.ch.qos.logback.core.db.DriverManagerConnectionSource.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36188](https://nvd.nist.gov/vuln/detail/CVE-2020-36188) | 8.1 | fixed in 2.6.7.5, 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to com.newrelic.agent.deps.ch.qos.logback.core.db.JNDIConnectionSource.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36187](https://nvd.nist.gov/vuln/detail/CVE-2020-36187) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp.datasources.SharedPoolDataSource.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36186](https://nvd.nist.gov/vuln/detail/CVE-2020-36186) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp.datasources.PerUserPoolDataSource.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36185](https://nvd.nist.gov/vuln/detail/CVE-2020-36185) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp2.datasources.SharedPoolDataSource.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36184](https://nvd.nist.gov/vuln/detail/CVE-2020-36184) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp2.datasources.PerUserPoolDataSource.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36183](https://nvd.nist.gov/vuln/detail/CVE-2020-36183) | 8.1 | fixed in 2.6.7.5, 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.docx4j.org.apache.xalan.lib.sql.JNDIConnectionPool.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36182](https://nvd.nist.gov/vuln/detail/CVE-2020-36182) | 8.1 | fixed in 2.6.7.5, 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp2.cpdsadapter.DriverAdapterCPDS.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36181](https://nvd.nist.gov/vuln/detail/CVE-2020-36181) | 8.1 | fixed in 2.6.7.5, 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp.cpdsadapter.DriverAdapterCPDS.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36179](https://nvd.nist.gov/vuln/detail/CVE-2020-36179) | 8.1 | fixed in 2.6.7.5, 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to oadd.org.apache.commons.dbcp.cpdsadapter.DriverAdapterCPDS.
high | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003) | 7.5 | fixed in 2.13.4.1, 2.12.7.1 | In FasterXML jackson-databind before versions 2.13.4.1 and 2.12.17.1, resource exhaustion can occur because of a lack of a check in primitive value deserializers to avoid deep wrapper array nesting, when the UNWRAP_SINGLE_VALUE_ARRAYS feature is enabled.
high | sca-package/build.gradle | org.apache.logging.log4j_log4j-core | [CVE-2021-45105](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45105) | 7.5 | fixed in 2.17.0, 2.12.3, 2.3.1 | Apache Log4j2 versions 2.0-alpha1 through 2.16.0 (excluding 2.12.3 and 2.3.1) did not protect from uncontrolled recursion from self-referential lookups. This allows an attacker with control over Thread Context Map data to cause a denial of service when a crafted string is interpreted. This issue was fixed in Log4j 2.17.0, 2.12.3, and 2.3.1.
high | sca-package/build.gradle | com.google.guava_guava | [CVE-2023-2976](https://nvd.nist.gov/vuln/detail/CVE-2023-2976) | 7.1 | fixed in 32.0.0 | Use of Java\'s default temporary directory for file creation in `FileBackedOutputStream` in Google Guava versions 1.0 to 31.1 on Unix systems and Android Ice Cream Sandwich allows other users and apps on the machine with access to the default Java temporary directory to be able to access the files created by the class.  Even though the security vulnerability is fixed in version 32.0.0, we recommend using version 32.0.1 as version 32.0.0 breaks some functionality under Windows.  
high | sca-package/go.sum | gopkg.in/yaml.v3 | [CVE-2022-28948](https://nvd.nist.gov/vuln/detail/CVE-2022-28948) | 7.5 | fixed in 3.0.0-20220521103104-8f96da9f5d5e | An issue in the Unmarshal function in Go-Yaml v3 causes the program to crash when attempting to deserialize invalid input.
high | sca-package/go.sum | github.com/go-git/go-git/v5 | [CVE-2023-49568](https://nvd.nist.gov/vuln/detail/CVE-2023-49568) | 7.5 | fixed in 5.11.0 | ### Impact A denial of service (DoS) vulnerability was discovered in go-git versions prior to `v5.11`. This vulnerability allows an attacker to perform denial of service attacks by providing specially crafted responses from a Git server which triggers resource exhaustion in `go-git` clients.   Applications using only the in-memory filesystem supported by `go-git` are not affected by this vulnerability. This is a `go-git` implementation issue and does not affect the upstream `git` cli.  ### Patches Users running versions of `go-git` from `v4` and above are recommended to upgrade to `v5.11` in order to mitigate this vulnerability.  ### Workarounds In cases where a bump to the latest version of `go-git` is not possible, we recommend limiting its use to only trust-worthy Git servers.  ## Credit Thanks to Ionut Lalu for responsibly disclosing this vulnerability to us.  ### References - [GHSA-mw99-9chc-xw7r](https://github.com/go-git/go-git/security/advisories/GHSA-mw99-9chc-xw7r) 
high | sca-package/go.sum | golang.org/x/crypto | [CVE-2021-43565](https://nvd.nist.gov/vuln/detail/CVE-2021-43565) | 7.5 | fixed in 0.0.0-20211202192323-5770296d904e | The x/crypto/ssh package before 0.0.0-20211202192323-5770296d904e of golang.org/x/crypto allows an attacker to panic an SSH server.
high | sca-package/go.sum | golang.org/x/crypto | [CVE-2022-27191](https://nvd.nist.gov/vuln/detail/CVE-2022-27191) | 7.5 | fixed in 0.0.0-20220314234659-1baeb1ce4c0b | The golang.org/x/crypto/ssh package before 0.0.0-20220314234659-1baeb1ce4c0b for Go allows an attacker to crash a server in certain circumstances involving AddHostKey.
high | sca-package/go.sum | github.com/hashicorp/go-getter | [CVE-2022-30323](https://nvd.nist.gov/vuln/detail/CVE-2022-30323) | 8.6 | fixed in 2.1.0, 1.6.1 | go-getter up to 1.5.11 and 2.0.2 panicked when processing password-protected ZIP files. Fixed in 1.6.1 and 2.1.0.
high | sca-package/go.sum | github.com/hashicorp/go-getter | [CVE-2022-30322](https://nvd.nist.gov/vuln/detail/CVE-2022-30322) | 8.6 | fixed in 2.1.0, 1.6.1 | go-getter up to 1.5.11 and 2.0.2 allowed asymmetric resource exhaustion when go-getter processed malicious HTTP responses. Fixed in 1.6.1 and 2.1.0.
high | sca-package/go.sum | github.com/hashicorp/go-getter | [CVE-2022-30321](https://nvd.nist.gov/vuln/detail/CVE-2022-30321) | 8.6 | fixed in 2.1.0, 1.6.1 | go-getter up to 1.5.11 and 2.0.2 allowed arbitrary host access via go-getter path traversal, symlink processing, and command injection flaws. Fixed in 1.6.1 and 2.1.0.
high | sca-package/go.sum | github.com/elazarl/goproxy | [CVE-2023-37788](https://nvd.nist.gov/vuln/detail/CVE-2023-37788) | 7.5 | fixed in 0.0.0-20230731152917-f99041a5c027 | goproxy v1.1 was discovered to contain an issue which can lead to a Denial of service (DoS) via unspecified vectors.
high | sca-package/go.sum | golang.org/x/text | [CVE-2021-38561](https://nvd.nist.gov/vuln/detail/CVE-2021-38561) | 7.5 | fixed in 0.3.7 | golang.org/x/text/language in golang.org/x/text before 0.3.7 can panic with an out-of-bounds read during BCP 47 language tag parsing. Index calculation is mishandled. If parsing untrusted user input, this can be used as a vector for a denial-of-service attack.
high | sca-package/go.sum | golang.org/x/text | [CVE-2022-32149](https://nvd.nist.gov/vuln/detail/CVE-2022-32149) | 7.5 | fixed in 0.3.8 | An attacker may cause a denial of service by crafting an Accept-Language header which ParseAcceptLanguage will take significant time to parse.
high | sca-package/go.sum | google.golang.org/grpc | [GHSA-m425-mq94-257g](https://github.com/advisories/GHSA-m425-mq94-257g) | 7.5 | fixed in 1.58.3, 1.57.1, 1.56.3 | ### Impact In affected releases of gRPC-Go, it is possible for an attacker to send HTTP/2 requests, cancel them, and send subsequent requests, which is valid by the HTTP/2 protocol, but would cause the gRPC-Go server to launch more concurrent method handlers than the configured maximum stream limit.  ### Patches This vulnerability was addressed by #6703 and has been included in patch releases: 1.56.3, 1.57.1, 1.58.3.  It is also included in the latest release, 1.59.0.  Along with applying the patch, users should also ensure they are using the `grpc.MaxConcurrentStreams` server option to apply a limit to the server\'s resources used for any single connection.  ### Workarounds None.  ### References #6703 
high | sca-package/go.sum | golang.org/x/net | [CVE-2022-41723](https://nvd.nist.gov/vuln/detail/CVE-2022-41723) | 7.5 | fixed in 0.7.0 | A maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests.
high | sca-package/go.sum | golang.org/x/net | [CVE-2022-27664](https://nvd.nist.gov/vuln/detail/CVE-2022-27664) | 7.5 | fixed in 0.0.0-20220906165146-f3363e06e74c | In net/http in Go before 1.18.6 and 1.19.x before 1.19.1, attackers can cause a denial of service because an HTTP/2 connection can hang during closing if shutdown were preempted by a fatal error.
high | sca-package/go.sum | golang.org/x/net | [CVE-2023-39325](https://nvd.nist.gov/vuln/detail/CVE-2023-39325) | 7.5 | fixed in 0.17.0 | A malicious HTTP/2 client which rapidly creates requests and immediately resets them can cause excessive server resource consumption. While the total number of requests is bounded by the http2.Server.MaxConcurrentStreams setting, resetting an in-progress request allows the attacker to create a new request while the existing one is still executing. With the fix applied, HTTP/2 servers now bound the number of simultaneously executing handler goroutines to the stream concurrency limit (MaxConcurrentStreams). New requests arriving when at the limit (which can only happen after the client has reset an existing, in-flight request) will be queued until a handler exits. If the request queue grows too large, the server will terminate the connection. This issue is also fixed in golang.org/x/net/http2 for users manually configuring HTTP/2. The default stream concurrency limit is 250 streams (requests) per HTTP/2 connection. This value may be adjusted using the golang.org/x/net/http2 package; see the Server.MaxConcurrentStreams setting and the ConfigureServer function.
high | sca-package/go.sum | github.com/prometheus/client_golang | [CVE-2022-21698](https://nvd.nist.gov/vuln/detail/CVE-2022-21698) | 7.5 | fixed in 1.11.1 | client_golang is the instrumentation library for Go applications in Prometheus, and the promhttp package in client_golang provides tooling around HTTP servers and clients. In client_golang prior to version 1.11.1, HTTP server is susceptible to a Denial of Service through unbounded cardinality, and potential memory exhaustion, when handling requests with non-standard HTTP methods. In order to be affected, an instrumented software must use any of `promhttp.InstrumentHandler*` middleware except `RequestsInFlight`; not filter any specific methods (e.g GET) before middleware; pass metric with `method` label name to our middleware; and not have any firewall/LB/proxy that filters away requests with unknown `method`. client_golang version 1.11.1 contains a patch for this issue. Several workarounds are available, including removing the `method` label name from counter/gauge used in the InstrumentHandler; turning off affected promhttp handlers; adding custom middleware before promhttp handler that will sanitize the request method given by Go http.Request; and using a reverse proxy or web application firewall, configured to only allow a limited set of methods.
medium | sca-package/requirements.txt | django | [CVE-2016-6186](https://nvd.nist.gov/vuln/detail/CVE-2016-6186) | 6.1 | fixed in 1.9.8, 1.8.14 | Cross-site scripting (XSS) vulnerability in the dismissChangeRelatedObjectPopup function in contrib/admin/static/admin/js/admin/RelatedObjectLookups.js in Django before 1.8.14, 1.9.x before 1.9.8, and 1.10.x before 1.10rc1 allows remote attackers to inject arbitrary web script or HTML via vectors involving unsafe usage of Element.innerHTML.
medium | sca-package/requirements.txt | django | [CVE-2021-33203](https://nvd.nist.gov/vuln/detail/CVE-2021-33203) | 4.9 | fixed in 3.2.4, 3.1.12, 2.2.24 | Django before 2.2.24, 3.x before 3.1.12, and 3.2.x before 3.2.4 has a potential directory traversal via django.contrib.admindocs. Staff members could use the TemplateDetailView view to check the existence of arbitrary files. Additionally, if (and only if) the default admindocs templates have been customized by application developers to also show file contents, then not only the existence but also the file contents would have been exposed. In other words, there is directory traversal outside of the template root directories.
medium | sca-package/requirements.txt | django | [CVE-2015-8213](https://nvd.nist.gov/vuln/detail/CVE-2015-8213) | 5.0 | fixed in 1.8.7, 1.7.11, 1.7.x | The get_format function in utils/formats.py in Django before 1.7.x before 1.7.11, 1.8.x before 1.8.7, and 1.9.x before 1.9rc2 might allow remote attackers to obtain sensitive application secrets via a settings key in place of a date/time format setting, as demonstrated by SECRET_KEY.
medium | sca-package/requirements.txt | django | [CVE-2015-2317](https://nvd.nist.gov/vuln/detail/CVE-2015-2317) | 4.3 | fixed in 1.8.1, 1.7.7, 1.6.11,... | The utils.http.is_safe_url function in Django before 1.4.20, 1.5.x, 1.6.x before 1.6.11, 1.7.x before 1.7.7, and 1.8.x before 1.8c1 does not properly validate URLs, which allows remote attackers to conduct cross-site scripting (XSS) attacks via a control character in a URL, as demonstrated by a \\x08javascript: URL.
medium | sca-package/requirements.txt | django | [CVE-2015-2241](https://nvd.nist.gov/vuln/detail/CVE-2015-2241) | 4.3 | fixed in 1.8, 1.7.6 | Cross-site scripting (XSS) vulnerability in the contents function in admin/helpers.py in Django before 1.7.6 and 1.8 before 1.8b2 allows remote attackers to inject arbitrary web script or HTML via a model attribute in ModelAdmin.readonly_fields, as demonstrated by a @property.
medium | sca-package/requirements.txt | django | [CVE-2015-0222](https://nvd.nist.gov/vuln/detail/CVE-2015-0222) | 5.0 | fixed in 1.7.3, 1.6.10, 1.4.18 | ModelMultipleChoiceField in Django 1.6.x before 1.6.10 and 1.7.x before 1.7.3, when show_hidden_initial is set to True, allows remote attackers to cause a denial of service by submitting duplicate values, which triggers a large number of SQL queries.
medium | sca-package/requirements.txt | django | [CVE-2015-0221](https://nvd.nist.gov/vuln/detail/CVE-2015-0221) | 5.0 | fixed in 1.7.3, 1.6.10, 1.4.18 | The django.views.static.serve view in Django before 1.4.18, 1.6.x before 1.6.10, and 1.7.x before 1.7.3 reads files an entire line at a time, which allows remote attackers to cause a denial of service (memory consumption) via a long line in a file.
medium | sca-package/requirements.txt | django | [CVE-2015-0220](https://nvd.nist.gov/vuln/detail/CVE-2015-0220) | 4.3 | fixed in 1.7.3, 1.6.10, 1.4.18 | The django.util.http.is_safe_url function in Django before 1.4.18, 1.6.x before 1.6.10, and 1.7.x before 1.7.3 does not properly handle leading whitespaces, which allows remote attackers to conduct cross-site scripting (XSS) attacks via a crafted URL, related to redirect URLs, as demonstrated by a \"\njavascript:\" URL.
medium | sca-package/requirements.txt | django | [CVE-2015-0219](https://nvd.nist.gov/vuln/detail/CVE-2015-0219) | 5.0 | fixed in 1.7.3, 1.6.10, 1.4.18 | Django before 1.4.18, 1.6.x before 1.6.10, and 1.7.x before 1.7.3 allows remote attackers to spoof WSGI headers by using an _ (underscore) character instead of a - (dash) character in an HTTP header, as demonstrated by an X-Auth_User header.
medium | sca-package/requirements.txt | django | [CVE-2015-5144](https://nvd.nist.gov/vuln/detail/CVE-2015-5144) | 4.3 | fixed in 1.8.3, 1.7.10, 1.7.9,... | Django before 1.4.21, 1.5.x through 1.6.x, 1.7.x before 1.7.9, and 1.8.x before 1.8.3 uses an incorrect regular expression, which allows remote attackers to inject arbitrary headers and conduct HTTP response splitting attacks via a newline character in an (1) email message to the EmailValidator, a (2) URL to the URLValidator, or unspecified vectors to the (3) validate_ipv4_address or (4) validate_slug validator.
medium | sca-package/requirements.txt | requests | [CVE-2023-32681](https://nvd.nist.gov/vuln/detail/CVE-2023-32681) | 6.1 | fixed in 2.31.0 | Requests is a HTTP library. Since Requests 2.3.0, Requests has been leaking Proxy-Authorization headers to destination servers when redirected to an HTTPS endpoint. This is a product of how we use `rebuild_proxies` to reattach the `Proxy-Authorization` header to requests. For HTTP connections sent through the tunnel, the proxy will identify the header in the request itself and remove it prior to forwarding to the destination server. However when sent over HTTPS, the `Proxy-Authorization` header must be sent in the CONNECT request as the proxy has no visibility into the tunneled request. This results in Requests forwarding proxy credentials to the destination server unintentionally, allowing a malicious actor to potentially exfiltrate sensitive information. This issue has been patched in version 2.31.0.  
medium | sca-package/package-lock.json | send | [CVE-2015-8859](https://nvd.nist.gov/vuln/detail/CVE-2015-8859) | 5.3 | fixed in 0.11.1 | The send package before 0.11.1 for Node.js allows attackers to obtain the root path via unspecified vectors.
medium | sca-package/package-lock.json | connect | [CVE-2018-3717](https://nvd.nist.gov/vuln/detail/CVE-2018-3717) | 5.4 | fixed in 2.14.0 | connect node module before 2.14.0 suffers from a Cross-Site Scripting (XSS) vulnerability due to a lack of validation of file in directory.js middleware.
medium | sca-package/pom.xml | org.apache.httpcomponents_httpclient | [CVE-2020-13956](https://nvd.nist.gov/vuln/detail/CVE-2020-13956) | 5.3 | fixed in 5.0.3, 4.5.13 | Apache HttpClient versions prior to version 4.5.13 and 5.0.3 can misinterpret malformed authority component in request URIs passed to the library as java.net.URI object and pick the wrong target host for request execution.
medium | sca-package/pom.xml | org.apache.httpcomponents_httpclient | [CVE-2015-5262](https://nvd.nist.gov/vuln/detail/CVE-2015-5262) | 4.3 | fixed in 4.4.1, 4.3.6 | http/conn/ssl/SSLConnectionSocketFactory.java in Apache HttpComponents HttpClient before 4.3.6 ignores the http.socket.timeout configuration setting during an SSL handshake, which allows remote attackers to cause a denial of service (HTTPS call hang) via unspecified vectors.
medium | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-core | [PRISMA-2023-0069](https://github.com/FasterXML/jackson-core/issues/315) | 5.3 | fixed in 2.7.7 | com.fasterxml.jackson.core_jackson-core package versions before 2.7.7 are vulnerable to Denial of Service (DoS). When the WRITE_BIGDECIMAL_AS_PLAIN is enabled the package will attempt to write out the whole number, no matter how large the exponent, which will cause OutOfMemoryError when writing BigDecimal.
medium | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-core | [PRISMA-2023-0068](https://github.com/FasterXML/jackson-core/pull/322) | 5.3 | fixed in 2.8.6 | com.fasterxml.jackson.core_jackson-core package versions before 2.8.6 are vulnerable to Denial of Service (DoS). If the REST endpoint consumes POST requests with JSON or XML data and data are invalid, the first unrecognized token is printed to server.log. If the first token is word of length 10MB, the whole word is printed. This is potentially dangerous and can be used to attack the server by filling the disk with logs.
medium | sca-package/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2023-35116](https://nvd.nist.gov/vuln/detail/CVE-2023-35116) | 4.7 | fixed in 2.16.0 | jackson-databind through 2.15.2 allows attackers to cause a denial of service or other unspecified impact via a crafted object that uses cyclic dependencies. NOTE: the vendor\'s perspective is that this is not a valid vulnerability report, because the steps of constructing a cyclic data structure and trying to serialize it cannot be achieved by an external attacker.
medium | sca-package/build.gradle | org.apache.logging.log4j_log4j-core | [CVE-2021-44832](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-44832) | 6.6 | fixed in 2.17.1, 2.12.4, 2.3.2 | Apache Log4j2 versions 2.0-beta7 through 2.17.0 (excluding security fix releases 2.3.2 and 2.12.4) are vulnerable to a remote code execution (RCE) attack when a configuration uses a JDBC Appender with a JNDI LDAP data source URI when an attacker has control of the target LDAP server. This issue is fixed by limiting JNDI data source names to the java protocol in Log4j2 versions 2.17.1, 2.12.4, and 2.3.2.
medium | sca-package/go.sum | github.com/sirupsen/logrus | [PRISMA-2023-0056](https://github.com/sirupsen/logrus/issues/1370) | 6.2 | fixed in v1.9.3 | The github.com/sirupsen/logrus module of all versions is vulnerable to denial of service. Logging more than 64kb of data in a single entry without newlines causes the log writer function to hang indefinitely.
moderate | sca-package/go.sum | go.etcd.io/etcd | [CVE-2018-1099](https://nvd.nist.gov/vuln/detail/CVE-2018-1099) | 5.5 | fixed in 3.4.0 | DNS rebinding vulnerability found in etcd 3.3.1 and earlier. An attacker can control his DNS records to direct to localhost, and trick the browser into sending requests to localhost (or any other address).
moderate | sca-package/go.sum | golang.org/x/crypto | [CVE-2023-48795](https://nvd.nist.gov/vuln/detail/CVE-2023-48795) | 5.9 | fixed in 0.17.0 | a flaw was found in the ssh channel integrity. by manipulating sequence numbers during the handshake, an attacker can remove the initial messages on the secure channel without causing a mac failure. for example, an attacker could disable the ping extension and thus disable the new countermeasure in openssh 9.5 against keystroke timing attacks.
moderate | sca-package/go.sum | golang.org/x/image | [CVE-2022-41727](https://nvd.nist.gov/vuln/detail/CVE-2022-41727) | 5.5 | fixed in 0.5.0 | An attacker can craft a malformed TIFF image which will consume a significant amount of memory when passed to DecodeConfig. This could lead to a denial of service.
moderate | sca-package/go.sum | golang.org/x/image | [CVE-2023-29408](https://nvd.nist.gov/vuln/detail/CVE-2023-29408) | 6.5 | fixed in 0.10.0 | The TIFF decoder does not place a limit on the size of compressed tile data. A maliciously-crafted image can exploit this to cause a small image (both in terms of pixel width/height, and encoded size) to make the decoder decode large amounts of compressed data, consuming excessive memory and CPU.
moderate | sca-package/go.sum | golang.org/x/image | [CVE-2023-29407](https://nvd.nist.gov/vuln/detail/CVE-2023-29407) | 6.5 | fixed in 0.10.0 | A maliciously-crafted image can cause excessive CPU consumption in decoding. A tiled image with a height of 0 and a very large width can cause excessive CPU consumption, despite the image size (width * height) appearing to be zero.
moderate | sca-package/go.sum | github.com/hashicorp/go-getter | [CVE-2023-0475](https://nvd.nist.gov/vuln/detail/CVE-2023-0475) | 4.2 | fixed in 1.7.0 | HashiCorp go-getter up to 1.6.2 and 2.1.1 is vulnerable to decompression bombs. Fixed in 1.7.0 and 2.2.0.
moderate | sca-package/go.sum | github.com/hashicorp/go-getter | [CVE-2022-29810](https://nvd.nist.gov/vuln/detail/CVE-2022-29810) | 5.5 | fixed in 1.5.11 | The Hashicorp go-getter library before 1.5.11 does not redact an SSH key from a URL query parameter.
moderate | sca-package/go.sum | golang.org/x/sys | [CVE-2022-29526](https://nvd.nist.gov/vuln/detail/CVE-2022-29526) | 5.3 | fixed in 0.0.0-20220412211240-33da011f77ad | Go before 1.17.10 and 1.18.x before 1.18.2 has Incorrect Privilege Assignment. When called with a non-zero flags parameter, the Faccessat function could incorrectly report that a file is accessible.
moderate | sca-package/go.sum | google.golang.org/grpc | [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487) | 5.3 | fixed in 1.56.3, 1.57.1, 1.58.3 | The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.
moderate | sca-package/go.sum | golang.org/x/net | [CVE-2023-3978](https://nvd.nist.gov/vuln/detail/CVE-2023-3978) | 6.1 | fixed in 0.13.0 | Text nodes not in the HTML namespace are incorrectly literally rendered, causing text which should be escaped to not be. This could lead to an XSS attack.
moderate | sca-package/go.sum | golang.org/x/net | [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487) | 5.3 | fixed in 0.17.0 | The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.
low | sca-package/build.gradle | com.google.guava_guava | [CVE-2020-8908](https://nvd.nist.gov/vuln/detail/CVE-2020-8908) | 3.3 | fixed in 32.0.0 | A temp directory creation vulnerability exists in all versions of Guava, allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava API com.google.common.io.Files.createTempDir(). By default, on unix-like systems, the created directory is world-readable (readable by an attacker with access to the system). The method in question has been marked @Deprecated in versions 30.0 and later and should not be used. For Android developers, we recommend choosing a temporary directory API provided by Android, such as context.getCacheDir(). For other Java developers, we recommend migrating to the Java 7 API java.nio.file.Files.createTempDirectory() which explicitly configures permissions of 700, or configuring the Java runtime\'s java.io.tmpdir system property to point to a location whose permissions are appropriately configured.  
low | sca-package/go.sum | github.com/Masterminds/goutils | [GHSA-xg2h-wx96-xgxr](https://github.com/advisories/GHSA-xg2h-wx96-xgxr) | 1.0 | fixed in 1.1.1 | ### Impact  A security-sensitive bug was discovered by Open Source Developer *Erik Sundell of Sundell Open Source Consulting AB*.  The functions `RandomAlphaNumeric(int)` and `CryptoRandomAlphaNumeric(int)` are not as random as they should be. Small values of `int` in the functions above will return a smaller subset of results than they should. For example, `RandomAlphaNumeric(1)` will always return a digit in the 0-9 range, while `RandomAlphaNumeric(4)` will return around ~7 million of the ~13M possible permutations.  This is considered a security release because programs that rely upon random generators for passwords are at an increased risk of brute force-style password guessing. There is also a higher probability of collision.  The problem was the result of a mistaken regular expression that only accepted random strings if they contained a digit from `[0-9]`. That restriction has been removed.  ### Patches  This issue has been corrected in v1.1.1.  ### Workarounds  If you cannot upgrade to v1.1.1, you can work around the issue by calling `RandomAlphaNumericCustom(N, true, true)`|`CryptoRandomAlphaNumericCustom(N, true, true)`  instead. (Where `N` is the desired length, and `true` is the literal boolean `true`.)        
